### PR TITLE
feat: add note edit and delete

### DIFF
--- a/src/features/feedback/ui/feedback-button.tsx
+++ b/src/features/feedback/ui/feedback-button.tsx
@@ -32,7 +32,7 @@ export function FeedbackButton() {
         title={t('feedback.description')}
       >
         <Bug className="h-4 w-4" />
-        {t('feedback.button')}
+        <span className="hidden sm:inline">{t('feedback.button')}</span>
       </Button>
 
       <FeedbackModal

--- a/src/features/history/ui/index.ts
+++ b/src/features/history/ui/index.ts
@@ -1,0 +1,5 @@
+export { NoteItem } from './note-item';
+export { NoteActions } from './note-actions';
+export { NotesList } from './notes-list';
+export { NotesSkeleton } from './notes-skeleton';
+export { ShowMoreButton } from './show-more-button';

--- a/src/features/history/ui/note-actions.tsx
+++ b/src/features/history/ui/note-actions.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/shared/ui/button';
+import { Textarea } from '@/shared/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/shared/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui/dropdown-menu';
+import { MoreVertical, Edit, Trash2 } from 'lucide-react';
+import { useTranslation } from '@/shared/contexts/translation-context';
+import { useUpdateNote, useDeleteNote } from '@/entities/note';
+import { useAlertContext } from '@/shared/providers/alert-provider';
+import type { Note } from '@/shared/types/notes';
+
+interface NoteActionsProps {
+  note: Note;
+}
+
+export function NoteActions({ note }: NoteActionsProps) {
+  const { t } = useTranslation();
+  const { showSuccess } = useAlertContext();
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editContent, setEditContent] = useState(note.note || '');
+
+  const updateNoteMutation = useUpdateNote();
+  const deleteNoteMutation = useDeleteNote();
+
+  const handleEdit = () => {
+    setEditContent(note.note || '');
+    setIsEditing(true);
+  };
+
+  const handleSave = async () => {
+    await updateNoteMutation.mutateAsync({
+      noteId: note.id,
+      note: editContent,
+    });
+    showSuccess(t('history.updateSuccess'));
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditContent(note.note || '');
+    setIsEditing(false);
+  };
+
+  const handleDelete = async () => {
+    await deleteNoteMutation.mutateAsync(note.id);
+    showSuccess(t('history.deleteSuccess'));
+    setIsDeleteDialogOpen(false);
+  };
+
+  return (
+    <>
+      {/* Actions Menu */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <MoreVertical className="h-3 w-3" />
+            <span className="sr-only">{t('history.actions.menu')}</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={handleEdit}>
+            <Edit className="h-3 w-3 mr-2" />
+            {t('history.actions.edit')}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-red-600 focus:text-red-600 dark:text-red-400 dark:focus:text-red-400"
+          >
+            <Trash2 className="h-3 w-3 mr-2" />
+            {t('history.actions.delete')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Edit Dialog */}
+      <Dialog open={isEditing} onOpenChange={setIsEditing}>
+        <DialogContent className="sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>{t('history.actions.edit')}</DialogTitle>
+            <DialogDescription>
+              {t('history.editPlaceholder')}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Textarea
+              value={editContent}
+              onChange={e => setEditContent(e.target.value)}
+              placeholder={t('history.editPlaceholder')}
+              className="min-h-[200px] resize-none"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              disabled={updateNoteMutation.isPending}
+            >
+              {t('history.cancel')}
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={updateNoteMutation.isPending || !editContent.trim()}
+            >
+              {updateNoteMutation.isPending
+                ? t('history.saving')
+                : t('history.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('history.actions.confirmDeleteTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('history.actions.confirmDelete')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsDeleteDialogOpen(false)}
+              disabled={deleteNoteMutation.isPending}
+            >
+              {t('history.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteNoteMutation.isPending}
+            >
+              {deleteNoteMutation.isPending
+                ? t('history.saving')
+                : t('history.actions.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/history/ui/note-item.tsx
+++ b/src/features/history/ui/note-item.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from '@/shared/contexts/translation-context';
 import { useState } from 'react';
 import type { Note } from '@/shared/types/notes';
 import { formatDateForDisplay } from '@/shared/lib/date-utils';
+import { NoteActions } from './note-actions';
 
 interface NoteItemProps {
   note: Note;
@@ -29,9 +30,14 @@ export function NoteItem({ note }: NoteItemProps) {
   return (
     <Card className="relative py-4 px-4 gap-1">
       <CardHeader className="px-0">
-        <div className="flex items-center space-x-2 text-xs text-gray-500 dark:text-gray-400">
-          <Clock className="h-3 w-3" />
-          <span>{formatTime(note.created_at)}</span>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2 text-xs text-gray-500 dark:text-gray-400">
+            <Clock className="h-3 w-3" />
+            <span>{formatTime(note.created_at)}</span>
+          </div>
+
+          {/* Actions Menu */}
+          <NoteActions note={note} />
         </div>
       </CardHeader>
       <CardContent className="px-0">

--- a/src/shared/dictionaries/en.json
+++ b/src/shared/dictionaries/en.json
@@ -95,7 +95,14 @@
     "showLess": "Show less",
     "selectDate": "Select date",
     "expand": "Expand",
-    "collapse": "Collapse"
+    "collapse": "Collapse",
+    "actions": {
+      "menu": "Actions",
+      "edit": "Edit",
+      "delete": "Delete",
+      "confirmDelete": "Are you sure you want to delete this entry?",
+      "confirmDeleteTitle": "Delete Entry"
+    }
   },
   "languages": {
     "russian": "Русский",

--- a/src/shared/dictionaries/ru.json
+++ b/src/shared/dictionaries/ru.json
@@ -95,7 +95,14 @@
     "showLess": "Скрыть",
     "selectDate": "Выберите дату",
     "expand": "Развернуть",
-    "collapse": "Свернуть"
+    "collapse": "Свернуть",
+    "actions": {
+      "menu": "Действия",
+      "edit": "Редактировать",
+      "delete": "Удалить",
+      "confirmDelete": "Вы уверены, что хотите удалить эту запись?",
+      "confirmDeleteTitle": "Удалить запись"
+    }
   },
   "languages": {
     "russian": "Русский",

--- a/src/widgets/page-header/ui/user-info-dropdown.tsx
+++ b/src/widgets/page-header/ui/user-info-dropdown.tsx
@@ -38,12 +38,18 @@ export function UserInfoDropdown() {
     return null;
   }
 
+  const displayName = user.user_metadata?.name || user.email;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="flex items-center gap-2">
-          <User className="h-4 w-4" />
-          {user.user_metadata?.name || user.email}
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex items-center gap-2 min-w-0 max-w-[200px]"
+        >
+          <User className="h-4 w-4 flex-shrink-0" />
+          <span className="truncate text-left">{displayName}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64">

--- a/src/widgets/page-header/ui/user-info.tsx
+++ b/src/widgets/page-header/ui/user-info.tsx
@@ -12,12 +12,15 @@ export function UserInfo({ user }: UserInfoProps) {
 
   return (
     <div className="px-2 py-1.5 text-sm text-muted-foreground">
-      <p>
-        <strong>{t('auth.email')}:</strong> {user.email}
+      <p className="break-all">
+        <strong>{t('auth.email')}:</strong>
+        <span className="truncate block">{user.email}</span>
       </p>
-      <p>
+      <p className="break-all">
         <strong>{t('auth.name')}:</strong>{' '}
-        {user.user_metadata?.name || t('user.notFound')}
+        <span className="truncate block">
+          {user.user_metadata?.name || t('user.notFound')}
+        </span>
       </p>
       <p>
         <strong>{t('user.createdAt')}:</strong>{' '}


### PR DESCRIPTION
# 🚀 Добавлена функциональность редактирования и удаления notes

## Основные изменения

### 🔧 Новая функциональность
- Реализовано меню действий с троеточием (⋮) в правом верхнем углу каждой карточки note
- Добавлена возможность редактирования notes через модальное окно
- Реализовано удаление notes с подтверждением
- Интеграция с существующими хуками `useUpdateNote` и `useDeleteNote`

### 🎨 UI/UX улучшения
- Dropdown menu с иконками для действий (Edit, Trash2)
- Цветовое выделение кнопки удаления (красный цвет)
- Адаптивный дизайн для мобильных устройств
- Accessibility поддержка (sr-only для скринридеров)
- Состояния загрузки с отображением "Сохранение..."

## Результат
Пользователи теперь могут легко редактировать и удалять свои записи через удобное меню действий. Код стал более модульным, читаемым и поддерживаемым благодаря вынесению логики в отдельный компонент.